### PR TITLE
Added phone OTP + email verification in signup flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_firebase/screens/login_screen.dart';
-import 'firebase_options.dart';
 import 'package:flutter_firebase/home_screen.dart';
+import 'package:flutter_firebase/firebase_options.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,13 +19,38 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner:  false,
+      debugShowCheckedModeBanner: false,
       title: 'Flutter Firebase Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home:  LoginScreen(),
+      home:  AuthGate(),
+    );
+  }
+}
+
+class AuthGate extends StatelessWidget {
+  const AuthGate({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        // while checking auth state, show loader
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return  Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        // if user is logged in, go to Home
+        if (snapshot.hasData && snapshot.data != null) {
+          return HomeScreen();
+        }
+        // otherwise show login
+        return  LoginScreen();
+      },
     );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,8 +6,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_firebase/firebase_options.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({super.key});
-
   @override
   State<LoginScreen> createState() => _LoginScreenState();
 }
@@ -37,22 +35,32 @@ class _LoginScreenState extends State<LoginScreen> {
   }
 
   void _login() async {
-    if (emailController.text.isEmpty || passwordController.text.isEmpty) {
+    String email = emailController.text.trim();
+    String password = passwordController.text.trim();
+
+    if (email.isEmpty || password.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text("Please enter email and password")),
       );
       return;
     }
 
-    setState(() {
-      loading = true;
-    });
+    setState(() => loading = true);
 
     try {
-      await _auth.signInWithEmailAndPassword(
-        email: emailController.text.trim(),
-        password: passwordController.text.trim(),
+      UserCredential userCredential = await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
       );
+
+      // Check if email is verified
+      if (!userCredential.user!.emailVerified) {
+        await _auth.signOut();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Please verify your email before login.")),
+        );
+        return;
+      }
 
       if (!mounted) return;
       Navigator.pushReplacement(
@@ -68,9 +76,7 @@ class _LoginScreenState extends State<LoginScreen> {
         SnackBar(content: Text("Error: $e")),
       );
     } finally {
-      setState(() {
-        loading = false;
-      });
+      setState(() => loading = false);
     }
   }
 
@@ -84,12 +90,11 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.deepPurple.shade50, // soft background
+      backgroundColor: Colors.deepPurple.shade50,
       appBar: AppBar(
         title: Text('Login'),
         centerTitle: true,
         backgroundColor: Colors.deepPurple,
-        elevation: 0,
       ),
       body: Center(
         child: SingleChildScrollView(

--- a/lib/screens/otp_screen.dart
+++ b/lib/screens/otp_screen.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_firebase/home_screen.dart';
+
+class OtpScreen extends StatefulWidget {
+  final dynamic confirmationResult; // Web
+  final String? verificationId; // Mobile
+  final String email;
+  final String password;
+
+  OtpScreen({
+    Key? key,
+    this.confirmationResult,
+    this.verificationId,
+    required this.email,
+    required this.password,
+  }) : super(key: key);
+
+  @override
+  State<OtpScreen> createState() => _OtpScreenState();
+}
+
+class _OtpScreenState extends State<OtpScreen> {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final otpController = TextEditingController();
+  bool loading = false;
+
+  void _verifyOtp() async {
+    if (otpController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Please enter OTP")),
+      );
+      return;
+    }
+
+    setState(() => loading = true);
+
+    try {
+      UserCredential userCredential;
+
+      if (kIsWeb) {
+        userCredential = await widget.confirmationResult.confirm(
+          otpController.text.trim(),
+        );
+      } else {
+        PhoneAuthCredential credential = PhoneAuthProvider.credential(
+          verificationId: widget.verificationId!,
+          smsCode: otpController.text.trim(),
+        );
+        userCredential = await _auth.signInWithCredential(credential);
+      }
+
+      // Create email/password account
+      UserCredential emailUser =
+      await _auth.createUserWithEmailAndPassword(
+        email: widget.email,
+        password: widget.password,
+      );
+
+      // Send email verification
+      await emailUser.user!.sendEmailVerification();
+
+      // Show alert to user
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text("Email Verification Required"),
+          content: Text(
+              "A verification email has been sent to ${widget.email}. Please verify your email before continuing."),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                // Reload current user and check verification
+                await FirebaseAuth.instance.currentUser!.reload();
+                var user = FirebaseAuth.instance.currentUser;
+
+                if (user != null && user.emailVerified) {
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (_) => HomeScreen()),
+                        (route) => false,
+                  );
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                        content: Text(
+                            "Email not verified yet. Check your inbox.")),
+                  );
+                }
+              },
+              child: Text("I have verified"),
+            )
+          ],
+        ),
+      );
+    } on FirebaseAuthException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Error: ${e.message}")),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Unexpected error: $e")),
+      );
+    } finally {
+      setState(() => loading = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    otpController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.deepPurple.shade50,
+      appBar: AppBar(
+        title: Text("Verify OTP"),
+        centerTitle: true,
+        backgroundColor: Colors.deepPurple,
+        elevation: 0,
+      ),
+      body: Center(
+        child: Padding(
+          padding: EdgeInsets.all(20),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.message, size: 80, color: Colors.deepPurple),
+              SizedBox(height: 20),
+              Text(
+                "Enter the OTP sent to your phone",
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 30),
+              TextField(
+                controller: otpController,
+                keyboardType: TextInputType.number,
+                maxLength: 6,
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                  hintText: "Enter 6-digit OTP",
+                  counterText: "",
+                  filled: true,
+                  fillColor: Colors.white,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+              SizedBox(height: 30),
+              loading
+                  ? CircularProgressIndicator()
+                  : SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _verifyOtp,
+                  style: ElevatedButton.styleFrom(
+                    padding: EdgeInsets.symmetric(vertical: 14),
+                    backgroundColor: Colors.deepPurple,
+                    foregroundColor: Colors.white,
+                    textStyle: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: Text("Verify"),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/signup-screen.dart
+++ b/lib/screens/signup-screen.dart
@@ -1,13 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter_firebase/home_screen.dart';
-import 'login_screen.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter_firebase/firebase_options.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'otp_screen.dart';
 
 class SignupScreen extends StatefulWidget {
-  const SignupScreen({super.key});
-
   @override
   State<SignupScreen> createState() => _SignupScreenState();
 }
@@ -16,63 +12,85 @@ class _SignupScreenState extends State<SignupScreen> {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
+  final phoneController = TextEditingController();
   bool loading = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _initializeFirebase();
-  }
-
-  Future<void> _initializeFirebase() async {
-    try {
-      await Firebase.initializeApp(
-        options: DefaultFirebaseOptions.currentPlatform,
-      );
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Firebase init error: $e")),
-        );
-      }
-    }
+  // Simple email validator
+  bool isValidEmail(String email) {
+    return RegExp(r"^[a-zA-Z0-9\._%-]+@[a-zA-Z0-9\.-]+\.[a-zA-Z]{2,4}$")
+        .hasMatch(email);
   }
 
   void _signup() async {
-    if (emailController.text.isEmpty || passwordController.text.isEmpty) {
+    String email = emailController.text.trim();
+    String password = passwordController.text.trim();
+    String phone = phoneController.text.trim();
+
+    if (email.isEmpty || password.isEmpty || phone.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Please enter email and password")),
+        SnackBar(content: Text("Please fill all fields")),
       );
       return;
     }
 
-    setState(() {
-      loading = true;
-    });
+    if (!isValidEmail(email)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("Please enter a valid email address")),
+      );
+      return;
+    }
+
+    setState(() => loading = true);
 
     try {
-      await _auth.createUserWithEmailAndPassword(
-        email: emailController.text.trim(),
-        password: passwordController.text.trim(),
-      );
-
-      if (!mounted) return;
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (context) => const HomeScreen()),
-      );
-    } on FirebaseAuthException catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(e.message ?? "Signup failed")),
-      );
+      if (kIsWeb) {
+        //  Web: Phone verification
+        ConfirmationResult confirmationResult =
+        await _auth.signInWithPhoneNumber(phone);
+        if (!mounted) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => OtpScreen(
+              confirmationResult: confirmationResult,
+              email: email,
+              password: password,
+            ),
+          ),
+        );
+      } else {
+        //  Mobile: Phone verification
+        await _auth.verifyPhoneNumber(
+          phoneNumber: phone,
+          verificationCompleted: (PhoneAuthCredential credential) async {
+            await _auth.signInWithCredential(credential);
+          },
+          verificationFailed: (FirebaseAuthException e) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text("Phone verification failed: ${e.message}")),
+            );
+          },
+          codeSent: (String verificationId, int? resendToken) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => OtpScreen(
+                  verificationId: verificationId,
+                  email: email,
+                  password: password,
+                ),
+              ),
+            );
+          },
+          codeAutoRetrievalTimeout: (String verificationId) {},
+        );
+      }
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text("Error: $e")),
       );
     } finally {
-      setState(() {
-        loading = false;
-      });
+      setState(() => loading = false);
     }
   }
 
@@ -80,6 +98,7 @@ class _SignupScreenState extends State<SignupScreen> {
   void dispose() {
     emailController.dispose();
     passwordController.dispose();
+    phoneController.dispose();
     super.dispose();
   }
 
@@ -88,87 +107,98 @@ class _SignupScreenState extends State<SignupScreen> {
     return Scaffold(
       backgroundColor: Colors.deepPurple.shade50,
       appBar: AppBar(
-        title: Text('Sign Up'),
+        title: Text("Create Account"),
         centerTitle: true,
         backgroundColor: Colors.deepPurple,
-        elevation: 0,
       ),
       body: Center(
         child: SingleChildScrollView(
           padding: EdgeInsets.all(20),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(Icons.person_add_alt_1, size: 80, color: Colors.deepPurple),
-              SizedBox(height: 20),
-              Text(
-                'Create Account',
-                style: TextStyle(fontSize: 26, fontWeight: FontWeight.bold),
-              ),
-              SizedBox(height: 30),
-              TextField(
-                controller: emailController,
-                keyboardType: TextInputType.emailAddress,
-                decoration: InputDecoration(
-                  labelText: 'Email',
-                  prefixIcon: Icon(Icons.email_outlined),
-                  filled: true,
-                  fillColor: Colors.white,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-              ),
-              SizedBox(height: 20),
-              TextField(
-                controller: passwordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  labelText: 'Password',
-                  prefixIcon: Icon(Icons.lock_outline),
-                  filled: true,
-                  fillColor: Colors.white,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-              ),
-              SizedBox(height: 30),
-              loading
-                  ? CircularProgressIndicator()
-                  : SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: _signup,
-                  style: ElevatedButton.styleFrom(
-                    padding: EdgeInsets.symmetric(vertical: 14),
-                    backgroundColor: Colors.deepPurple,
-                    foregroundColor: Colors.white,
-                    textStyle: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
+          child: Card(
+            elevation: 6,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.person_add, size: 80, color: Colors.deepPurple),
+                  SizedBox(height: 10),
+                  Text("Sign Up",
+                      style: TextStyle(
+                          fontSize: 26,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.deepPurple)),
+                  SizedBox(height: 30),
+                  TextField(
+                    controller: emailController,
+                    decoration: InputDecoration(
+                      prefixIcon: Icon(Icons.email_outlined),
+                      labelText: "Email",
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      filled: true,
+                      fillColor: Colors.grey.shade100,
                     ),
                   ),
-                  child: Text('Sign Up'),
-                ),
+                  SizedBox(height: 16),
+                  TextField(
+                    controller: passwordController,
+                    obscureText: true,
+                    decoration: InputDecoration(
+                      prefixIcon: Icon(Icons.lock_outline),
+                      labelText: "Password",
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      filled: true,
+                      fillColor: Colors.grey.shade100,
+                    ),
+                  ),
+                  SizedBox(height: 16),
+                  TextField(
+                    controller: phoneController,
+                    keyboardType: TextInputType.phone,
+                    decoration: InputDecoration(
+                      prefixIcon: Icon(Icons.phone_android),
+                      labelText: "Phone Number (+923xxxxxxxxx)",
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      filled: true,
+                      fillColor: Colors.grey.shade100,
+                    ),
+                  ),
+                  SizedBox(height: 24),
+                  loading
+                      ? CircularProgressIndicator()
+                      : SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _signup,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.deepPurple,
+                        foregroundColor: Colors.white,
+                        padding: EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        textStyle: TextStyle(
+                            fontSize: 18, fontWeight: FontWeight.w600),
+                      ),
+                      child: Text("Sign Up"),
+                    ),
+                  ),
+                  if (kIsWeb) SizedBox(height: 20),
+                  if (kIsWeb)
+                    Text(
+                      "Complete the reCAPTCHA below before OTP",
+                      style: TextStyle(color: Colors.black54),
+                    ),
+                ],
               ),
-              SizedBox(height: 20),
-              TextButton(
-                onPressed: () {
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(builder: (context) => const LoginScreen()),
-                  );
-                },
-                child: Text(
-                  "Already have an account? Login",
-                  style: TextStyle(color: Colors.deepPurple),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/web/index.html
+++ b/web/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <!--
-    If you are serving your web app in a path other than the root, change the
-    href value below to reflect the base path you are serving from.
-
-    The path provided below has to start and end with a slash "/" in order for
-    it to work correctly.
-
-    For more details:
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-
-    This is a placeholder for base href that will be replaced by the value of
-    the `--base-href` argument provided to `flutter build`.
-  -->
   <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
@@ -31,8 +18,34 @@
 
   <title>flutter_firebase</title>
   <link rel="manifest" href="manifest.json">
+
+  <!-- ✅ Firebase SDKs -->
+  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js"></script>
+  <!-- (Optional) Analytics -->
+  <!-- <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-analytics.js"></script> -->
+
+  <script>
+    // ✅ Firebase config
+    const firebaseConfig = {
+      apiKey: "AIzaSyDD9bNTHn3n4bj-io35qqCHMptR1SA5wDs",
+      authDomain: "flutterfirebaseapp-2aa15.firebaseapp.com",
+      projectId: "flutterfirebaseapp-2aa15",
+      storageBucket: "flutterfirebaseapp-2aa15.appspot.com", // ✅ check this in console
+      messagingSenderId: "816695239528",
+      appId: "1:816695239528:web:9e9692222c7cfe99c2acdd",
+      measurementId: "G-YH094R3CFQ"
+    };
+
+    // ✅ Firebase initialize
+    firebase.initializeApp(firebaseConfig);
+    // firebase.analytics(); // (Optional)
+  </script>
 </head>
 <body>
-  <script src="flutter_bootstrap.js" async></script>
+<!-- 👇 Recaptcha container (required for web phone auth) -->
+<div id="recaptcha-container"></div>
+
+<script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
What’s New

Added OTP screen for phone verification.

Signup now requires Email + Password + Phone Number.

After signup: user enters 6-digit OTP → then email verification link is sent.

Fake/invalid emails are rejected.

Other Updates

main.dart → user stays logged in even after app restart (direct to HomeScreen).

Added reCAPTCHA + Firebase config in index.html for web support.

App works on both Mobile & Web.